### PR TITLE
- PH-4624 Add AMQP API for message sending in Connector

### DIFF
--- a/model/src/main/java/com/phorest/events/model/Command.java
+++ b/model/src/main/java/com/phorest/events/model/Command.java
@@ -1,0 +1,29 @@
+package com.phorest.events.model;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.joda.time.DateTime;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Command<T> {
+    @NotNull
+    private String commandId;
+    @NotNull
+    private DateTime timestamp;
+    @Valid
+    @NotNull
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "@type", visible = true)
+    private T payload;
+
+    public static <T> Command<T> create(T payload) {
+        return new Command<>(UUID.randomUUID().toString(), DateTime.now(), payload);
+    }
+}

--- a/model/src/main/java/com/phorest/events/model/Event.java
+++ b/model/src/main/java/com/phorest/events/model/Event.java
@@ -18,13 +18,29 @@ public class Event<T> {
     private String eventId;
     @NotNull
     private DateTime timestamp;
+    @Deprecated
     private String type;
+
+    /**
+     * Use {@link #payload} instead of it
+     */
     @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
     @Valid
-    @NotNull
+    @Deprecated
     private T data;
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "@type", visible = true)
+    @Valid
+    private T payload;
 
+    /**
+     * Use {@link #create} instead of it
+     */
+    @Deprecated
     public static <T extends EventData> Event<T> createNew(String type, T data) {
-        return new Event<>(UUID.randomUUID().toString(), DateTime.now(), type, data);
+        return new Event<>(UUID.randomUUID().toString(), DateTime.now(), type, data, null);
+    }
+
+    public static <T> Event<T> create(T payload) {
+        return new Event<>(UUID.randomUUID().toString(), DateTime.now(), null, null, payload);
     }
 }


### PR DESCRIPTION
- Added Command class
- Changed Event class - deprecated data property that contained fully qualified class name as a type info, instead of it payload property was added that will contain just type name. That change will allow us to deserialize both Events and Commands payloads to custom classes defined in separate repos