### PR TITLE
- PH-4624 Add AMQP API for message sending in Connector

### DIFF
--- a/configuration/src/main/java/com/phorest/events/configuration/RabbitListenerConfiguration.java
+++ b/configuration/src/main/java/com/phorest/events/configuration/RabbitListenerConfiguration.java
@@ -7,7 +7,6 @@ import org.springframework.amqp.rabbit.config.RetryInterceptorBuilder;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistrar;
-import org.springframework.amqp.rabbit.retry.RejectAndDontRequeueRecoverer;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -63,8 +62,4 @@ public class RabbitListenerConfiguration implements RabbitListenerConfigurer {
                 .build();
     }
 
-    @Bean
-    RejectAndDontRequeueRecoverer rejectAndDontRequeueRecoverer() {
-        return new RejectAndDontRequeueRecoverer();
-    }
 }

--- a/configuration/src/main/java/com/phorest/events/configuration/retry/DeadLetterPublishingMessageRecoverer.java
+++ b/configuration/src/main/java/com/phorest/events/configuration/retry/DeadLetterPublishingMessageRecoverer.java
@@ -1,0 +1,71 @@
+package com.phorest.events.configuration.retry;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.retry.MessageRecoverer;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.springframework.amqp.rabbit.retry.RepublishMessageRecoverer.*;
+
+public class DeadLetterPublishingMessageRecoverer implements MessageRecoverer {
+
+    public static final String X_DEAD_LETTER_EXCHANGE = "x-dead-letter-exchange";
+    public static final String X_DEAD_LETTER_ROUTING_KEY = "x-dead-letter-routing-key";
+
+    private static final Logger logger = LoggerFactory.getLogger(DeadLetterPublishingMessageRecoverer.class);
+
+    private RabbitTemplate rabbitTemplate;
+    private Map<String, Queue> queuesByName;
+
+    public DeadLetterPublishingMessageRecoverer(RabbitTemplate rabbitTemplate, List<Queue> queues) {
+        this.rabbitTemplate = rabbitTemplate;
+        this.queuesByName = queues.stream()
+                .collect(Collectors.toMap(Queue::getName, Function.identity()));
+    }
+
+    @Override
+    public void recover(Message message, Throwable cause) {
+        String consumerQueueName = message.getMessageProperties().getConsumerQueue();
+        Queue consumerQueue = queuesByName.get(consumerQueueName);
+        Map<String, Object> queueArguments = consumerQueue.getArguments();
+        Object deadLetterExchange = queueArguments.get(X_DEAD_LETTER_EXCHANGE);
+        Object deadLetterRoutingKey = queueArguments.get(X_DEAD_LETTER_ROUTING_KEY);
+
+        if (deadLetterExchange == null || deadLetterRoutingKey == null) {
+            logger.info("No dead letter exchange/routing key defined for queue: {}. Dropping message: {}", consumerQueueName, message.getMessageProperties().getMessageId());
+            return;
+        }
+        appendErrorHeaders(message, cause);
+        rabbitTemplate.send(deadLetterExchange.toString(), deadLetterRoutingKey.toString(), message);
+        logger.warn("Republishing failed message to exchange: {} with routing key: {}", deadLetterExchange, deadLetterRoutingKey);
+
+    }
+
+    private void appendErrorHeaders(Message message, Throwable cause) {
+        Map<String, Object> headers = message.getMessageProperties().getHeaders();
+        headers.put(X_EXCEPTION_STACKTRACE, getStackTraceAsString(cause));
+        headers.put(X_EXCEPTION_MESSAGE, cause.getCause() != null ? cause.getCause().getMessage() : cause.getMessage());
+        headers.put(X_ORIGINAL_EXCHANGE, message.getMessageProperties().getReceivedExchange());
+        headers.put(X_ORIGINAL_ROUTING_KEY, message.getMessageProperties().getReceivedRoutingKey());
+    }
+
+    protected void appendAdditionalErroHeaders(Message message, Throwable cause) {
+        //subclasses can override this method
+    }
+
+    private String getStackTraceAsString(Throwable cause) {
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter printWriter = new PrintWriter(stringWriter, true);
+        cause.printStackTrace(printWriter);
+        return stringWriter.getBuffer().toString();
+    }
+}

--- a/configuration/src/main/java/com/phorest/events/configuration/retry/DelayedRetryMessageRecoverer.java
+++ b/configuration/src/main/java/com/phorest/events/configuration/retry/DelayedRetryMessageRecoverer.java
@@ -3,15 +3,16 @@ package com.phorest.events.configuration.retry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.retry.MessageRecoverer;
-import org.springframework.amqp.rabbit.retry.RejectAndDontRequeueRecoverer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
+import java.util.List;
 import java.util.Map;
 
 @Profile("amqp")
@@ -29,7 +30,10 @@ public class DelayedRetryMessageRecoverer implements MessageRecoverer {
     private RetryDelayCalculator retryDelayCalculator;
 
     @Autowired
-    private RejectAndDontRequeueRecoverer rejectAndDontRequeueRecoverer;
+    private List<Queue> queues;
+
+    @Autowired(required = false)
+    private DeadLetterPublishingMessageRecoverer deadLetterPublishingMessageRecoverer;
 
     @Autowired(required = false)
     private RetryDecider retryDecider;
@@ -37,10 +41,15 @@ public class DelayedRetryMessageRecoverer implements MessageRecoverer {
     @Value("${phorest.events.configuration.rabbit.retry.maxRetryAttempts:10}")
     private int maxRetryAttempts;
 
+
     @PostConstruct
     public void init() {
         if (retryDecider == null) {
             retryDecider = new RetryDecider();
+        }
+
+        if (deadLetterPublishingMessageRecoverer == null) {
+            deadLetterPublishingMessageRecoverer = new DeadLetterPublishingMessageRecoverer(rabbitTemplate, queues);
         }
     }
 
@@ -51,7 +60,7 @@ public class DelayedRetryMessageRecoverer implements MessageRecoverer {
         int retryCount = (int) headers.getOrDefault(X_RETRY_COUNT, 0);
 
         if (shouldRetry(retryCount, cause)) {
-            log.warn("Retrying to deliver for routing key {}. Attempts: {}, reason: {}", originalRoutingKey, retryCount, cause.getMessage());
+            log.warn("Retrying to deliver for routing key {}. Attempts: {}, reason: {}", originalRoutingKey, retryCount, getCauseMessage(cause));
             headers.put(X_RETRY_COUNT, ++retryCount);
             message.getMessageProperties().setDelay((int) retryDelayCalculator.getDelayValue(retryCount));
             rabbitTemplate.send(message.getMessageProperties().getReceivedExchange(), originalRoutingKey, message);
@@ -69,8 +78,12 @@ public class DelayedRetryMessageRecoverer implements MessageRecoverer {
         return retryCount < maxRetryAttempts;
     }
 
+    private String getCauseMessage(Throwable cause) {
+        return cause.getCause() != null ? cause.getCause().getMessage() : cause.getMessage();
+    }
+
     private void rejectMessage(Message message, Throwable cause) {
-        rejectAndDontRequeueRecoverer.recover(message, cause);
+        deadLetterPublishingMessageRecoverer.recover(message, cause);
     }
 
 }

--- a/test-application/src/main/groovy/com/phorest/events/testapp/TestMessageListener.groovy
+++ b/test-application/src/main/groovy/com/phorest/events/testapp/TestMessageListener.groovy
@@ -12,6 +12,8 @@ import org.springframework.web.bind.annotation.RestController
 
 import javax.validation.Valid
 
+import static com.phorest.events.configuration.retry.DeadLetterPublishingMessageRecoverer.X_DEAD_LETTER_EXCHANGE
+import static com.phorest.events.configuration.retry.DeadLetterPublishingMessageRecoverer.X_DEAD_LETTER_ROUTING_KEY
 import static com.phorest.events.testapp.TestRabbitConfiguration.TEST_DLQ_ROUTING_KEY
 import static com.phorest.events.testapp.TestRabbitConfiguration.TEST_ERROR_EXCHANGE
 import static com.phorest.events.testapp.TestRabbitConfiguration.TEST_EXCHANGE
@@ -29,8 +31,8 @@ class TestMessageListener {
 
     @RabbitListener(bindings = @QueueBinding(
         value = @Queue(value = TEST_QUEUE, durable = "true", arguments = [
-            @Argument(name = "x-dead-letter-exchange", value = TEST_ERROR_EXCHANGE),
-            @Argument(name = "x-dead-letter-routing-key", value = TEST_DLQ_ROUTING_KEY)
+            @Argument(name = X_DEAD_LETTER_EXCHANGE, value = TEST_ERROR_EXCHANGE),
+            @Argument(name = X_DEAD_LETTER_ROUTING_KEY, value = TEST_DLQ_ROUTING_KEY)
         ]),
         exchange = @Exchange(value = TEST_EXCHANGE, type = ExchangeTypes.TOPIC, delayed = "true", durable = "true"),
         key = TEST_ROUTING_KEY)


### PR DESCRIPTION
- Added custom DeadLetterPublishingMessageRecoverer.java that publishes rejected message to configured dead letter exchange/routing key if defined